### PR TITLE
bit operations are now based on BitArray instead of byte array

### DIFF
--- a/Fenrir/PackDeltaMethods.fs
+++ b/Fenrir/PackDeltaMethods.fs
@@ -23,7 +23,7 @@ let byteToBits (num: byte) : BitArray =
 let bitsToInt (bits: BitArray): int =
     let mutable st = 1
 
-    seq { for b in bits do yield b }
+    Seq.cast<bool> bits
     |> Seq.fold (fun acc i ->
         let result = acc + (if i then 1 else 0) * st
         st <- st * 2

--- a/Fenrir/Packing.fs
+++ b/Fenrir/Packing.fs
@@ -1,6 +1,7 @@
 ﻿module Fenrir.Packing
 
 open System
+open System.Collections
 open System.IO
 
 open Fenrir.Zlib
@@ -10,13 +11,19 @@ open Fenrir.Tools
 let getPackPath (gitPath: String) (packFile: String) (extension: String) : String =
     Path.Combine(gitPath, "objects", "pack", packFile + extension)
 
-let bitKeys(key: String) : byte[] =
+let bitKeys (key: String): BitArray =
     match key with
-        | "commit" -> [| 0uy; 0uy; 1uy |]
-        | "tree"   -> [| 0uy; 1uy; 0uy |]
-        | "blob"   -> [| 0uy; 1uy; 1uy |]
-        | "tag"    -> [| 1uy; 0uy; 0uy |]
+        | "commit" -> BitArray [| true; false; false |]
+        | "tree"   -> BitArray [| false; true; false |]
+        | "blob"   -> BitArray [| true; true; false |]
+        | "tag"    -> BitArray [| false; false; true |]
         | _        -> failwithf "Unknown object type provided"
+
+let deltaKeys (key: String): BitArray =
+    match key with
+        | "ofs_delta" -> BitArray [| false; true; true |]
+        | "ref_delta" -> BitArray [| true; true; true |]
+        | _ -> failwithf "\"Undefined\" of \"not yet used\" bits provided"
 
 let getBigEndian (reader: BinaryReader) : int =
     reader.ReadInt32() |> Net.IPAddress.NetworkToHostOrder
@@ -47,10 +54,10 @@ let parseIndexOffset (path: String) (hash: String) : int =
         -1
 
 let rec parsePackInfo (path: String) (offset: int) (flag: String): MemoryStream =
-    let getStream (path : String) (hash : String) (flag : String) : MemoryStream =
+    let getStream (path: String) (hash: String) (flag: String): MemoryStream =
         let packs = Directory.GetFiles(Path.Combine(path, "objects", "pack"), "*.idx")
                     |> Array.map Path.GetFileName
-                    |> Array.map ((fun count (str : String) -> str.[0..str.Length - count - 1]) 4)
+                    |> Array.map ((fun count (str: String) -> str.[0..str.Length - count - 1]) 4)
         let mutable offset = -1
 
         let containingPack = packs |> Array.tryFind (fun item ->
@@ -73,13 +80,14 @@ let rec parsePackInfo (path: String) (offset: int) (flag: String): MemoryStream 
     packReader.BaseStream.Position <- int64 offset
 
     let sizeBytes = readWhileLast isMsbSet (uint64 packReader.BaseStream.Length) packReader
-    let bits = sizeBytes.[0] |> byteToBits |> Array.rev
-    let mutable size = bits.[4..7] |> bitsToInt
+    let bits = sizeBytes.[0] |> byteToBits
+    let mutable size = sliceBitArray bits 0 3 |> bitsToInt
 
     size <- estimateSize size 4 sizeBytes.[1..]
-    if bits.[1..3] = bitKeys(flag) then
+    let objectMask = sliceBitArray bits 4 6
+    if compareBitArrays <| objectMask <| bitKeys flag then
         new MemoryStream(size + 20 |> packReader.ReadBytes) |> getDecodedStream
-    else if bits.[1..3] = [| 1uy; 1uy; 0uy |] then
+    else if compareBitArrays <| objectMask <| deltaKeys "ofs_delta" then
         let mutable additional = 0
         let mutable offStep = 0
         let negOffset = (readWhileLast isMsbSet (uint64 packReader.BaseStream.Length) packReader
@@ -94,14 +102,14 @@ let rec parsePackInfo (path: String) (offset: int) (flag: String): MemoryStream 
         use stream = parsePackInfo path (offset - negOffset) flag
         use nonDeltaReader = new BinaryReader(stream)
         processDelta packReader nonDeltaReader size
-    else if bits.[1..3] =  [| 1uy; 1uy; 1uy |] then
+    else if compareBitArrays <| objectMask <| deltaKeys "ref_delta" then
         let hash = packReader |> readHash
         use stream = getStream path hash flag
         use nonDeltaReader = new BinaryReader(stream)
         processDelta packReader nonDeltaReader size
     else failwithf "wrong bits"
 
-let getPackedStream (path : String) (hash : String) (flag : String) : MemoryStream =
+let getPackedStream (path: String) (hash: String) (flag: String): MemoryStream =
     let packs = Directory.GetFiles(Path.Combine(path, "objects", "pack"), "*.idx")
                 |> Array.map Path.GetFileName
                 |> Array.map ((fun count (str : String) -> str.[0..str.Length - count - 1]) 4)

--- a/Fenrir/Tools.fs
+++ b/Fenrir/Tools.fs
@@ -3,6 +3,13 @@
 open System
 open System.IO
 open System.Globalization
+open System.Collections
+
+let sliceBitArray (bits: BitArray) (start: int) (finish: int): BitArray =
+    [| for b in bits do yield b |].[start..finish] |> BitArray
+
+let compareBitArrays (immut: BitArray) (mut: BitArray): bool =
+    seq {for b in mut.Xor immut do yield b} |> Seq.exists (fun item -> item = true) |> not
 
 let readWhile (condition: byte -> bool) (maxSize: uint64) (stream: BinaryReader): byte array =
     let rec makeList (n: uint64): byte list =


### PR DESCRIPTION
I coudn't find anything easier than seq convertion to operate with BitArrays:
`seq {for b in bits do yield b}`.

Hope that'll do.

Closes #42.