### PR TITLE
PackDeltaMethods: reset the stream after unpacking deltified object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog][keep-a-changelog]. See [the README fil
 ### Added
 - [#105](https://github.com/ForNeVeR/Fenrir/issues/105): `Refs.ReadHeadRef` function to read the contents of the `HEAD` file in the repository.
 
+### Fixed
+- [#106](https://github.com/ForNeVeR/Fenrir/issues/106): broken reading of objects packed using delta encoding.
+
 ### Changed
 - `Ref.Name` property is now nullable (to handle detached HEAD state).
 

--- a/Fenrir.Application/Program.fs
+++ b/Fenrir.Application/Program.fs
@@ -60,6 +60,9 @@ Usage:
 
     If any of the <input> or <output> parameters isn't defined, then standard input and/or standard output are used instead.
 
+  read-commit <path to .git/ directory> <commit-hash>
+    Read a commit from a repository and print its metadata.
+
   update-commit <id of commit> [<path to repository>] <path of file>
     Read updated text file from <path to repository>/<path of file> and save it as new object file to repository.
     Moreover, save new trees based on <id of commit> parent tree, its subtrees to repository and commit file.
@@ -191,6 +194,11 @@ let main (argv: string[]): int =
         use input = new FileStream(inputPath, FileMode.Open, FileAccess.Read, FileShare.Read)
         use output = new FileStream(outputPath, FileMode.CreateNew, FileAccess.Write)
         Zlib.unpackObject input output
+        ExitCodes.Success
+
+    | [|"read-commit"; repoPath; commitHash|] ->
+        let commit = Commands.parseCommitBody repoPath commitHash
+        printfn $"%A{commit}"
         ExitCodes.Success
 
     | [|"update-commit"; commitHash; filePath|] ->

--- a/Fenrir.Git/PackDeltaMethods.fs
+++ b/Fenrir.Git/PackDeltaMethods.fs
@@ -88,4 +88,5 @@ let processDelta (decodedStream: MemoryStream) (nonDelta: BinaryReader) (size: i
             applyDelta()
 
     applyDelta()
+    result.Position <- 0L
     result

--- a/Fenrir.Tests/PackTests.fs
+++ b/Fenrir.Tests/PackTests.fs
@@ -20,6 +20,8 @@ let private packTest (bom: bool) (hash: string) (source: string): unit =
         yield! File.ReadAllBytes <| Path.Combine(testDataRoot, source)
     |]
     let expected = expectedBytes |> toString
+    Assert.Equal(0L, packedObject.Stream.Position)
+
     let actual = packedObject.Stream.ToArray() |> toString
     Assert.Equal(expected, actual)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Usage:
 
     If any of the <input> or <output> parameters isn't defined, then standard input and/or standard output are used instead.
 
+  read-commit <path to .git/ directory> <commit-hash>
+    Read a commit from a repository and print its metadata.
+
   update-commit <id of commit> [<path to repository>] <path of file>
     Read updated text file from <path to repository>/<path of file> and save it as new object file to repository.
     Moreover, save new trees based on <id of commit> parent tree, its subtrees to repository and commit file.


### PR DESCRIPTION
The problem was that for any deltified entity, we were leaving the stream position at its end, which resulted in our inability to read anything from it.

Closes #106.